### PR TITLE
chore: Pin versions for required dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/rigetti/inkwell?branch=274-instruction-to-phi#629d1a2267f4ece122fdce5125ba2253ca9313eb"
+source = "git+https://github.com/rigetti/inkwell?rev=9929e859#9929e8595d9f3d1469a30e0afd1be791dcf2cbc3"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -214,7 +214,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.5.0"
-source = "git+https://github.com/rigetti/inkwell?branch=274-instruction-to-phi#629d1a2267f4ece122fdce5125ba2253ca9313eb"
+source = "git+https://github.com/rigetti/inkwell?rev=9929e859#9929e8595d9f3d1469a30e0afd1be791dcf2cbc3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/kalzoo/inkwell?branch=274-instruction-to-phi#33b44aada8d1356013b2a4c283f2ca9f38bef0e2"
+source = "git+https://github.com/rigetti/inkwell?branch=274-instruction-to-phi#629d1a2267f4ece122fdce5125ba2253ca9313eb"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -214,7 +214,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.5.0"
-source = "git+https://github.com/kalzoo/inkwell?branch=274-instruction-to-phi#33b44aada8d1356013b2a4c283f2ca9f38bef0e2"
+source = "git+https://github.com/rigetti/inkwell?branch=274-instruction-to-phi#629d1a2267f4ece122fdce5125ba2253ca9313eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -233,15 +233,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "similar",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -389,27 +380,25 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -723,6 +712,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 either = "1.6.1"
 env_logger = "0.9.0"
 eyre = "0.6.6"
-inkwell = { version = "0.1.0",  git = "https://github.com/rigetti/inkwell", branch = "274-instruction-to-phi", features = [
+inkwell = { version = "0.1.0",  git = "https://github.com/rigetti/inkwell", rev = "9929e859", features = [
     "target-x86",
 ] }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 either = "1.6.1"
 env_logger = "0.9.0"
 eyre = "0.6.6"
-inkwell = { version = "0.1.0",  git = "https://github.com/kalzoo/inkwell", branch = "274-instruction-to-phi", features = [
+inkwell = { version = "0.1.0",  git = "https://github.com/rigetti/inkwell", branch = "274-instruction-to-phi", features = [
     "target-x86",
 ] }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-either = "*"
+either = "1.6.1"
 env_logger = "0.9.0"
 eyre = "0.6.6"
-inkwell = { git = "https://github.com/kalzoo/inkwell", branch = "274-instruction-to-phi", features = [
+inkwell = { version = "0.1.0",  git = "https://github.com/kalzoo/inkwell", branch = "274-instruction-to-phi", features = [
     "target-x86",
 ] }
 lazy_static = "1.4.0"
 log = "0.4.14"
-num-complex = "*"
+num-complex = "0.4.0"
 quil-rs = "0.8.5"
 regex = "1.5.4"
 structopt = "0.3.21"


### PR DESCRIPTION
This is to make `cargo-deny` happy downstream