### PR TITLE
ci: convert workflow to locally usable scripts

### DIFF
--- a/.github/workflows/release-unix.yml
+++ b/.github/workflows/release-unix.yml
@@ -1,6 +1,8 @@
-on:
-  release:
-    types: [created]
+on: push
+
+# on:
+#   release:
+#     types: [created]
 
 name: Release SDK & Utils (macos/linux)
 
@@ -35,16 +37,15 @@ jobs:
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "${{ matrix.llvm_version }}.0"
-        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
-
-    - name: Check LLVM installation
-      run: llvm-config --version
 
     - name: Install missing LLVM deps
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-key C99B11DEB97541F0
         sudo apt-get update && sudo apt-get install -y libtinfo5 cmake
+    
+    - name: Check LLVM installation
+      run: llvm-config --version
 
     - name: Install cargo-make
       uses: actions-rs/cargo@v1
@@ -59,62 +60,16 @@ jobs:
 
     - name: Setup release build environment
       run: |
-        # set defaults for dynamic CI variables when local/testing
-        CHECK_TAG=${{ github.ref_name }}
-        if [[ $CHECK_TAG = "" ]]; then
-          TAG=${{ env.TESTING_TAG }}
-        else 
-          TAG=${{ github.ref_name }}
-        fi
+        C_SDK_VERSION=${{ env.C_SDK_VERSION }} \
+        LLVM_VERSION=${{ env.LLVM_VERSION }} \
+        TESTING_TAG=${{ env.TESTING_TAG }} \
+        TAG=${{ github.ref_name }} \
+        ./scripts/release/setup.sh
 
-        SDK_BIN=qcs-sdk-qir
-        ARCH=$(uname -m)
-        OS=$(uname -s | awk '{print tolower($0)}')
-        DIST=${SDK_BIN}-llvm${{ env.LLVM_VERSION }}-${OS}-${ARCH}-${TAG}  
-        DIST_DIR=${DIST}/dist
-        DIST_ABS_PATH=$(pwd)/${DIST_DIR}
-        ARCHIVE=${DIST}.tar.gz
-        CHECKSUM=${DIST}.checksum.txt
-
-        echo "TAG=${TAG}" >> $GITHUB_ENV
-        echo "SDK_BIN=${SDK_BIN}" >> $GITHUB_ENV
-        echo "ARCH=${ARCH}" >> $GITHUB_ENV
-        echo "OS=${OS}" >> $GITHUB_ENV
-        echo "DIST=${DIST}" >> $GITHUB_ENV
-        echo "DIST_DIR=${DIST_DIR}" >> $GITHUB_ENV
-        echo "DIST_ABS_PATH=${DIST_ABS_PATH}" >> $GITHUB_ENV
-        echo "ARCHIVE=${ARCHIVE}" >> $GITHUB_ENV
-        echo "CHECKSUM=${CHECKSUM}" >> $GITHUB_ENV
-
-        # print out all env variables
-        cat $GITHUB_ENV
-
-        # create paths to collect artifacts
-        mkdir -p ${DIST_ABS_PATH}/lib
+        cat .release-env >> $GITHUB_ENV
 
     - name: Install build environment dependencies
       uses: lukka/get-cmake@latest
-
-    - name: Build release artifacts (linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        # build the QIR SDK binary
-        cargo build --bin ${{ env.SDK_BIN }} --release --features llvm${{ matrix.llvm_version }}-0
-        
-        # build the QCS C SDK shared library
-        git clone https://github.com/rigetti/qcs-sdk-c ../qcs-sdk-c
-        pushd ../qcs-sdk-c
-        git fetch --all --tags
-        git checkout tags/${{ env.C_SDK_VERSION}} -b build-qir-sdk-${{ env.TAG}}
-        cargo build --release
-        popd
-        
-        # build the SDK helper library
-        pushd helper
-        cp helper.h helper.c
-        clang -c -o libhelper.o helper.c -fPIE
-        clang -shared -o libhelper.so libhelper.o
-        popd
 
     - name: Install xcode / devtools (macos)
       uses: maxim-lobanov/setup-xcode@v1
@@ -122,73 +77,11 @@ jobs:
         xcode-version: latest-stable
       if: matrix.os == 'macos-latest'
 
-    - name: Build release artifacts (macos)
-      if: matrix.os == 'macos-latest'
-      run: |
-        # build the QIR SDK binary
-        cargo build --bin ${{ env.SDK_BIN }} --release --features llvm${{ matrix.llvm_version }}-0
-        
-        # build the QCS C SDK shared library
-        git clone https://github.com/rigetti/qcs-sdk-c ../qcs-sdk-c
-        pushd ../qcs-sdk-c
-        git fetch --all --tags
-        git checkout tags/${{ env.C_SDK_VERSION}} -b build-qir-sdk-${{ env.TAG}}
-        cargo build --release
-        popd
-        
-        # build the SDK helper library
-        pushd helper
-        cp helper.h helper.c
-        gcc-11 -L../../qcs-sdk-c/target/release -lqcs -dynamiclib helper.c -o libhelper.dylib
-        popd
-      
-    - name: Collect release artifacts (linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        # collect the QIR SDK binary
-        cp target/release/${{ env.SDK_BIN }} ${{ env.DIST_ABS_PATH }}
-        
-        # collect the licenses & README
-        cp LICENSE ${{ env.DIST_ABS_PATH }}
-        sed -i -- 's/#TAG#/${{ env.TAG }}/g' .github/workflows/README.release.md
-        cp .github/workflows/README.release.md ${{ env.DIST_ABS_PATH }}/README.md
+    - name: Build release artifacts
+      run: ./scripts/release/build.sh
 
-        # collect the QCS C SDK shared library
-        pushd ../qcs-sdk-c
-        cp target/release/libqcs.so ${{ env.DIST_ABS_PATH }}/lib
-        popd
-
-        # collect the SDK helper library
-        pushd helper
-        cp libhelper.so ${{ env.DIST_ABS_PATH }}/lib
-        popd
-
-    - name: Collect release artifacts (macos)
-      if: matrix.os == 'macos-latest'
-      run: |
-        # collect the QIR SDK binary
-        cp target/release/${{ env.SDK_BIN }} ${{ env.DIST_ABS_PATH }}
-        
-        # collect the licenses & README
-        cp LICENSE ${{ env.DIST_ABS_PATH }}
-        sed -i -- 's/#TAG#/${{ env.TAG }}/g' .github/workflows/README.release.md
-        cp .github/workflows/README.release.md ${{ env.DIST_ABS_PATH }}/README.md
-
-        # collect the QCS C SDK shared library
-        pushd ../qcs-sdk-c
-        cp target/release/libqcs.dylib ${{ env.DIST_ABS_PATH }}/lib
-        popd
-
-        # collect the SDK helper library
-        pushd helper
-        cp libhelper.dylib ${{ env.DIST_ABS_PATH }}/lib
-        popd
-
-    - name: Create release archive
-      run: |
-        tar -cvzf ${{ env.ARCHIVE }} ${{ env.DIST_DIR }}/*
-        ls -ll ${ARCHIVE}
-        shasum -a 256 ${{ env.ARCHIVE }} > ${{ env.CHECKSUM }}
+    - name: Collect release artifacts and build archive
+      run: ./scripts/release/archive.sh
 
     - name: Upload archive to CI summary
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release-unix.yml
+++ b/.github/workflows/release-unix.yml
@@ -1,8 +1,6 @@
-on: push
-
-# on:
-#   release:
-#     types: [created]
+on:
+  release:
+    types: [created]
 
 name: Release SDK & Utils (macos/linux)
 
@@ -19,6 +17,7 @@ jobs:
     env:
       C_SDK_VERSION: v0.1.0
       LLVM_VERSION: ${{ matrix.llvm_version }}
+      LLVM_FULL_VERSION: ${{ matrix.llvm_version }}.0.1
       TESTING_TAG: v0.0.0-local
     steps:
     - name: Checkout sources
@@ -53,29 +52,26 @@ jobs:
         command: install
         args: --debug cargo-make
 
+    - name: Install build environment dependencies
+      uses: lukka/get-cmake@latest
+
     - name: Run cargo build, test, fmt, clippy
       env:
         LLVM_FEATURE: llvm${{ matrix.llvm_version }}-0
+        PROFILE: "release"
       run: cargo make ci-flow
 
     - name: Setup release build environment
       run: |
         C_SDK_VERSION=${{ env.C_SDK_VERSION }} \
         LLVM_VERSION=${{ env.LLVM_VERSION }} \
+        LLVM_FULL_VERSION=${{ env.LLVM_FULL_VERSION }} \
         TESTING_TAG=${{ env.TESTING_TAG }} \
         TAG=${{ github.ref_name }} \
+        CI=${CI} \
         ./scripts/release/setup.sh
 
         cat .release-env >> $GITHUB_ENV
-
-    - name: Install build environment dependencies
-      uses: lukka/get-cmake@latest
-
-    - name: Install xcode / devtools (macos)
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-      if: matrix.os == 'macos-latest'
 
     - name: Build release artifacts
       run: ./scripts/release/build.sh
@@ -86,7 +82,7 @@ jobs:
     - name: Upload archive to CI summary
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ env.DIST }}-artifacts.zip
+        name: ${{ env.RELEASE }}-artifacts
         path: |
           ${{ env.ARCHIVE }}
           ${{ env.CHECKSUM }}
@@ -94,6 +90,7 @@ jobs:
     - name: Upload archive to Release ${{ env.TAG }}
       if: env.TAG != env.TESTING_TAG
       uses: softprops/action-gh-release@v1
+      continue-on-error: true
       with:
         files: |
           ${{ env.ARCHIVE }}

--- a/.github/workflows/release-unix.yml
+++ b/.github/workflows/release-unix.yml
@@ -90,7 +90,6 @@ jobs:
     - name: Upload archive to Release ${{ env.TAG }}
       if: env.TAG != env.TESTING_TAG
       uses: softprops/action-gh-release@v1
-      continue-on-error: true
       with:
         files: |
           ${{ env.ARCHIVE }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ target/
 .idea/
 
 # release artifacts
-qcs-sdk-qir-*
+dist
+qcs-sdk-qir-llvm*
 tmp-deps-build
 .release-env
 helper/libhelper.*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 
 target/
 .idea/
+
+# release artifacts
+qcs-sdk-qir-*
+tmp-deps-build
+.release-env
+helper/libhelper.*
+helper/helper.c

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,8 +4,12 @@ LLVM_FEATURE = { value = "llvm13-0", condition = { env_not_set = [
     "LLVM_FEATURE",
 ] } }
 PROFILE = { value = "dev", condition = { env_not_set = ["PROFILE"] } }
-C_SDK_BUILD = { value = "1", condition = { env_not_set = ["C_SDK_BUILD"] } }
-QIR_SDK_BUILD = { value = "1", condition = { env_not_set = ["QIR_SDK_BUILD"] } }
+NO_C_SDK_BUILD = { value = "0", condition = { env_not_set = [
+    "NO_C_SDK_BUILD",
+] } }
+NO_QIR_SDK_BUILD = { value = "0", condition = { env_not_set = [
+    "NO_QIR_SDK_BUILD",
+] } }
 
 [tasks.assemble-llvm]
 command = "find"
@@ -34,7 +38,10 @@ command = "./scripts/release/setup.sh"
 
 [tasks.release-build]
 command = "./scripts/release/build.sh"
-args = ["C_SDK_BUILD: ${C_SDK_BUILD}", "QIR_SDK_BUILD: ${QIR_SDK_BUILD}"]
+args = [
+    "NO_C_SDK_BUILD: ${NO_C_SDK_BUILD}",
+    "NO_QIR_SDK_BUILD: ${NO_QIR_SDK_BUILD}",
+]
 
 [tasks.release-archive]
 command = "./scripts/release/archive.sh"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,6 +3,9 @@ RUST_BACKTRACE = 0
 LLVM_FEATURE = { value = "llvm13-0", condition = { env_not_set = [
     "LLVM_FEATURE",
 ] } }
+PROFILE = { value = "dev", condition = { env_not_set = ["PROFILE"] } }
+C_SDK_BUILD = { value = "1", condition = { env_not_set = ["C_SDK_BUILD"] } }
+QIR_SDK_BUILD = { value = "1", condition = { env_not_set = ["QIR_SDK_BUILD"] } }
 
 [tasks.assemble-llvm]
 command = "find"
@@ -15,20 +18,29 @@ args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
 command = "cargo"
-args = ["clippy", "--features", "${LLVM_FEATURE}"]
+args = ["clippy", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}"]
 
 [tasks.pre-ci-flow]
 dependencies = ["format-check", "clippy"]
 
 [tasks.build]
-args = ["build", "--features", "${LLVM_FEATURE}"]
+args = ["build", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}"]
 
 [tasks.test]
-args = ["test", "--features", "${LLVM_FEATURE}"]
+args = ["test", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}"]
 
-[tasks.quick-release]
-script = [
-    "./scripts/release/setup.sh",
-    "./scripts/release/build.sh",
-    "./scripts/release/archive.sh",
-]
+[tasks.release-setup]
+command = "./scripts/release/setup.sh"
+
+[tasks.release-build]
+command = "./scripts/release/build.sh"
+args = ["C_SDK_BUILD: ${C_SDK_BUILD}", "QIR_SDK_BUILD: ${QIR_SDK_BUILD}"]
+
+[tasks.release-archive]
+command = "./scripts/release/archive.sh"
+
+[tasks.release-quick]
+dependencies = ["release-setup", "release-build", "release-archive"]
+
+[tasks.release-clean]
+command = "./scripts/release/clean.sh"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,6 +10,9 @@ NO_C_SDK_BUILD = { value = "0", condition = { env_not_set = [
 NO_QIR_SDK_BUILD = { value = "0", condition = { env_not_set = [
     "NO_QIR_SDK_BUILD",
 ] } }
+NO_HELPER_LIB_BUILD = { value = "0", condition = { env_not_set = [
+    "NO_HELPER_LIB_BUILD",
+] } }
 
 [tasks.assemble-llvm]
 command = "find"
@@ -41,6 +44,7 @@ command = "./scripts/release/build.sh"
 args = [
     "NO_C_SDK_BUILD: ${NO_C_SDK_BUILD}",
     "NO_QIR_SDK_BUILD: ${NO_QIR_SDK_BUILD}",
+    "NO_HELPER_LIB_BUILD: ${NO_HELPER_LIB_BUILD}",
 ]
 
 [tasks.release-archive]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,8 @@
 [env]
-RUST_BACKTRACE=0
-LLVM_FEATURE = {value = "llvm13-0", condition = {env_not_set = ["LLVM_FEATURE"]}}
+RUST_BACKTRACE = 0
+LLVM_FEATURE = { value = "llvm13-0", condition = { env_not_set = [
+    "LLVM_FEATURE",
+] } }
 
 [tasks.assemble-llvm]
 command = "find"
@@ -23,3 +25,10 @@ args = ["build", "--features", "${LLVM_FEATURE}"]
 
 [tasks.test]
 args = ["test", "--features", "${LLVM_FEATURE}"]
+
+[tasks.quick-release]
+script = [
+    "./scripts/release/setup.sh",
+    "./scripts/release/build.sh",
+    "./scripts/release/archive.sh",
+]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ NO_C_SDK_BUILD=1 NO_QIR_SDK_BUILD=1 NO_HELPER_LIB_BUILD=1 cargo make release-qui
 Refer to the included `README.md` in your own local release build, which will help you test your
 changes if you are looking to transform and compile QIR programs. 
 
+To reset your environment and clean up release build artifacts, run:
+```sh
+cargo make release-clean
+```
+
 ## Examples
 
 Given an input QIR program that might look like this:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,60 @@
 
 Compile & run Quantum Intermediate Representation (QIR) programs on Rigetti QCS.
 
+## Usage 
+
+The easiest way to start is by downloading the [latest release](https://github.com/rigetti/qcs-sdk-qir/releases/latest).
+
+Within the release, you will find a `README.md` pertaining to the specific version you've downloaded,
+based on [this template](./scripts/release/README.release.md). Those instructions cover the basics
+to compile an executable that can run quantum programs on Rigetti QPUs or the QVM.
+
+## Development
+
+In order to build this crate, a supported LLVM version must be installed and available on your `PATH` 
+(you must be able to run `llvm-config`). The supported versions are listed in `Cargo.toml` under 
+`[features]`.
+
+To build the CLI: 
+```sh
+cargo build --bin qcs-sdk-qir --features llvm13-0
+```
+
+To run the unit and snapshot tests: 
+```sh
+cargo test --features llvm13-0
+```
+
+To test your changes alongside the shared libraries, it might be helpful to reuse the release 
+scripts and test a fully integrated toolset. To do so, it's recommended to use `cargo-make`. Install
+it by running:
+```sh
+cargo install cargo-make
+```
+
+Use the following task and configurations to build the SDK with your changes:
+```sh
+cargo make release-quick # skips the Rust unit and snapshot tests & and other checks
+```
+
+After this, you can skip building various components if a new build is not necessary: 
+```sh
+# any or all of the following env vars can be used:
+NO_C_SDK_BUILD=1 NO_QIR_SDK_BUILD=1 NO_HELPER_LIB_BUILD=1 cargo make release-quick
+
+# NO_C_SDK_BUILD: skips the git clone & build of the `qcs-sdk-c` library (default: 0)
+# NO_QIR_SDK_BUILD: skips the build of this repo (default: 0)
+# NO_HELPER_LIB_BUILD: skips the build of the helper lib (default: 0)
+```
+
+Refer to the included `README.md` in your own local release build, which will help you test your
+changes if you are looking to transform and compile QIR programs. 
+
 ## Examples
 
 Given an input QIR program that might look like this:
 
-```LLVM
+```llvm
 %Qubit = type opaque
 %Result = type opaque
 
@@ -48,7 +97,7 @@ This library will:
 
 After this process is complete, the above snippet might look like this (once disassembled):
 
-```LLVM
+```llvm
 ; ModuleID = 'program.bc'
 source_filename = "./test/fixtures/programs/measure.ll"
 
@@ -108,46 +157,45 @@ entry:
 }
 ```
 
-## Setup
+---
 
-In order to build this crate, a supported LLVM version installed and available on your `PATH` (you must be able to run `llvm-config`). The supported versions are listed in `Cargo.toml` under `[features]`.
+_Read the following for a more detailed run-down on usage / development:_
 
-Build the CLI using `cargo build --bin qcs-sdk-qir --features llvm13-0`.
-
-### Extra Dependencies for [Full QIR Conversion](#transform-qir)
+## Extra Dependencies for [Full QIR Conversion](#transform-qir)
 
 > These are not required if only [transforming unitary QIR to Quil](#transpile-qir-to-quil).
 
-* A C compiler, such as `gcc` or `clang`, which supports LLVM 11 at a minimum. For OSX users, this means XCode version >= 12.5.
+* A C compiler, such as `gcc` or `clang`, which supports LLVM 11 at a minimum. For OSX users, this 
+means XCode version >= 12.5.
 * The QCS SDK shared library, which may be built or downloaded as described [here](https://github.com/rigetti/qcs-sdk-c). 
 
-You'll also need to compile the shared "helper" library contained in the `helper` directory. This small shared library is used to reduce the complexity required within this crate's LLVM transformations.
+You'll also need to compile the shared "helper" library contained in the `helper` directory. This 
+small shared library is used to reduce the complexity required within this crate's LLVM 
+transformations.
 
 ```sh
 cd helper
 ./build.sh
 ```
 
-Once that's compiled, make sure to set the relevant environment variables to point to it, within the terminal where you'll be transpiling and running your QIR programs:
+Once that's compiled, make sure to set the relevant environment variables to point to it, within the 
+terminal where you'll be transpiling and running your QIR programs:
 
 ```sh
 # Linux
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/qcs-sdk-qir/helper
 
 # OSX
-export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/qcs-sdk-qir/helper
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/path/to/qcs-sdk-qir/helper
 
 # Windows? (To be verified)
 export PATH=$PATH:/path/to/qcs-sdk-qir/helper
 ```
 
-### Development Dependencies
-
-[cargo-make](https://github.com/sagiegurari/cargo-make) is used as a task runner - install that with `cargo install cargo-make`.
-
 ## Transform QIR
 
-To transpile an input QIR program, run the CLI. Note that you **must specify your LLVM version corresponding with your installed version or this will fail with dozens of errors**:
+To transpile an input QIR program, run the CLI. Note that you **must specify your LLVM version 
+corresponding with your installed version or this will fail with dozens of errors**:
 
 ```
 cargo run --features llvm13-0 transform path/to/input.bc path/to/output.bc --add-main-entrypoint
@@ -234,11 +282,16 @@ error: No suitable version of LLVM was found system-wide or pointed
 
 ```
 
-First, make sure you do in fact have the same LLVM version installed and on your `PATH` as you've specified with the `--features` option in `cargo`. Run `llvm-config --version` to confirm. If not, that needs fixing first.
+First, make sure you do in fact have the same LLVM version installed and on your `PATH` as you've 
+specified with the `--features` option in `cargo`. Run `llvm-config --version` to confirm. If not, 
+that needs fixing first.
 
-If you do, perhaps you first tried to build the crate before LLVM was installed and configured. Run `cargo clean -p llvm-sys` to clear the build and then retry.
+If you do, perhaps you first tried to build the crate before LLVM was installed and configured. Run 
+`cargo clean -p llvm-sys` to clear the build and then retry.
 
-You may also want to try setting the `LLVM_SYS_<version>_PREFIX` environment variable to point to the LLVM installation you want to use. For example, if you've installed LLVM 13 via Homebrew on macOS, try `export LLVM_SYS_130_PREFIX=/usr/local/opt/llvm`.
+You may also want to try setting the `LLVM_SYS_<version>_PREFIX` environment variable to point to 
+the LLVM installation you want to use. For example, if you've installed LLVM 13 via Homebrew on 
+macOS, try `export LLVM_SYS_130_PREFIX=/usr/local/opt/llvm`.
 
 ### gcc compilation error: ld: library not found for -lhelper
 

--- a/scripts/release/README.release.md
+++ b/scripts/release/README.release.md
@@ -1,7 +1,8 @@
 # Rigetti QIR SDK
 
-Thank you for downloading the qcs-sdk-qir toolkit. In this release, you should find the following files:
+Thank you for downloading the `qcs-sdk-qir` toolkit. 
 
+In this release, you should find the following files:
 - `qcs-sdk-qir`: an executable binary used to transform QIR programs
 - `lib/libhelper.{dylib,so}`: a shared library to ease the use of the QCS SDK 
 - `lib/libqcs.{dylib,so}`: a shared library to handle communication between your QIR program and Rigetti's Quantum Cloud Services
@@ -13,7 +14,7 @@ In order to transform QIR programs, please follow these steps (take note of plat
 ### Linux
 
 ```bash 
-export ARCHIVE_NAME=qcs-sdk-qir-llvm12-linux-x86_64-#TAG#
+export ARCHIVE_NAME=qcs-sdk-qir-llvm#LLVM_VERSION#-linux-x86_64-#TAG#
 
 # verify the download:
 shasum -c $ARCHIVE_NAME.checksum.txt
@@ -41,7 +42,7 @@ clang -Llib -lqcs -Llib -lhelper output.bc -o program
 ### MacOS
 
 ```bash
-export ARCHIVE_NAME=qcs-sdk-qir-llvm12-darwin-x86_64-#TAG#
+export ARCHIVE_NAME=qcs-sdk-qir-llvm#LLVM_VERSION#-darwin-x86_64-#TAG#
 
 # verify the download:
 shasum -c $ARCHIVE_NAME.checksum.txt

--- a/scripts/release/archive.sh
+++ b/scripts/release/archive.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+source .release-env
+
+# collect the QIR SDK binary
+cp target/release/${SDK_BIN} ${DIST_ABS_PATH}
+
+# collect the licenses & README
+cp LICENSE ${DIST_ABS_PATH}
+sed -i -- "s/#TAG#/${TAG}/g" scripts/release/README.release.md
+sed -i -- "s/#LLVM_VERSION#/${LLVM_VERSION}/g" scripts/release/README.release.md
+cp scripts/release/README.release.md ${DIST_ABS_PATH}/README.md
+rm -f scripts/release/README.release.md--
+
+# collect the QCS C SDK shared library
+pushd ${TMP_DEPS_ABS_PATH}/qcs-sdk-c
+cp target/release/libqcs.${LIB_EXT} ${DIST_ABS_PATH}/lib
+popd
+
+# collect the SDK helper library
+pushd helper
+cp libhelper.${LIB_EXT} ${DIST_ABS_PATH}/lib
+popd
+
+# create the archive
+tar -cvzf ${ARCHIVE} ${DIST_DIR}/*
+ls -ll ${ARCHIVE}
+shasum -a 256 ${ARCHIVE} > ${CHECKSUM}

--- a/scripts/release/archive.sh
+++ b/scripts/release/archive.sh
@@ -8,10 +8,12 @@ cp target/release/${SDK_BIN} ${DIST_ABS_PATH}
 
 # collect the licenses & README
 cp LICENSE ${DIST_ABS_PATH}
+cp scripts/release/README.release.md scripts/release/README.release.md.local
 sed -i -- "s/#TAG#/${TAG}/g" scripts/release/README.release.md
 sed -i -- "s/#LLVM_VERSION#/${LLVM_VERSION}/g" scripts/release/README.release.md
 cp scripts/release/README.release.md ${DIST_ABS_PATH}/README.md
 rm -f scripts/release/README.release.md--
+mv scripts/release/README.release.md.local scripts/release/README.release.md
 
 # collect the QCS C SDK shared library
 pushd ${TMP_DEPS_ABS_PATH}/qcs-sdk-c
@@ -24,6 +26,6 @@ cp libhelper.${LIB_EXT} ${DIST_ABS_PATH}/lib
 popd
 
 # create the archive
-tar -cvzf ${ARCHIVE} ${DIST_DIR}/*
+tar -cvzf ${ARCHIVE} ${DIST_DIR}
 ls -ll ${ARCHIVE}
 shasum -a 256 ${ARCHIVE} > ${CHECKSUM}

--- a/scripts/release/build.sh
+++ b/scripts/release/build.sh
@@ -4,14 +4,14 @@ set -xeo pipefail
 source .release-env
 
 # build the QIR SDK binary
-if [[ $QIR_SDK_BUILD -eq 1 ]]; then
+if [[ $NO_QIR_SDK_BUILD -eq 0 ]]; then
     cargo build --bin ${SDK_BIN} --release --features llvm${LLVM_VERSION}-0
 else 
     echo "Skipping QIR SDK build."
 fi
 
 # build the QCS C SDK shared library
-if [[ $C_SDK_BUILD -eq 1 ]]; then
+if [[ $NO_C_SDK_BUILD -eq 0 ]]; then
     rm -rf ${TMP_DEPS_ABS_PATH}/qcs-sdk-c
     git clone https://github.com/rigetti/qcs-sdk-c ${TMP_DEPS_ABS_PATH}/qcs-sdk-c
     pushd ${TMP_DEPS_ABS_PATH}/qcs-sdk-c

--- a/scripts/release/build.sh
+++ b/scripts/release/build.sh
@@ -23,9 +23,13 @@ else
     echo "Skipping C SDK build."
 fi
 
+if [[ $NO_HELPER_LIB_BUILD -eq 0 ]]; then
 # build the SDK helper library
 pushd helper
 cp helper.h helper.c
 clang -c -o libhelper.o helper.c -fPIC
 clang -shared -L${TMP_DEPS_ABS_PATH}/qcs-sdk-c/target/release -lqcs -o libhelper.$LIB_EXT libhelper.o
 popd
+else 
+    echo "Skipping helper lib build."
+fi

--- a/scripts/release/build.sh
+++ b/scripts/release/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+source .release-env
+
+# build the QIR SDK binary
+cargo build --bin ${SDK_BIN} --release --features llvm${LLVM_VERSION}-0
+
+# build the QCS C SDK shared library
+rm -rf ${TMP_DEPS_ABS_PATH}/qcs-sdk-c
+git clone https://github.com/rigetti/qcs-sdk-c ${TMP_DEPS_ABS_PATH}/qcs-sdk-c
+pushd ${TMP_DEPS_ABS_PATH}/qcs-sdk-c
+git fetch --all --tags
+git checkout tags/${C_SDK_VERSION} -b build-qir-sdk-${TAG}
+cargo build --release
+popd
+
+# build the SDK helper library
+pushd helper
+cp helper.h helper.c
+clang -c -o libhelper.o helper.c -fPIE
+clang -shared -L${TMP_DEPS_ABS_PATH}/qcs-sdk-c/target/release -lqcs -o libhelper.$LIB_EXT libhelper.o
+popd

--- a/scripts/release/clean.sh
+++ b/scripts/release/clean.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+DELETE=(
+    "dist" 
+    "tmp-deps-build" 
+    ".release-env"
+    $(echo qcs-sdk-qir-llvm*) 
+    $(echo helper/libhelper.*) 
+    "helper/helper.c"
+)
+
+echo "The following will be deleted:"
+echo ""
+printf "    %s\n" "${DELETE[@]}"
+echo ""
+echo "Continue? (y/n)"
+read CONFIRM
+
+if [[ $CONFIRM = "y" ]]; then
+    for f in "${DELETE[@]}"; do
+        rm -rf $f
+    done
+else 
+    echo "Clean cancelled."
+fi

--- a/scripts/release/setup.sh
+++ b/scripts/release/setup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+# set defaults for dynamic CI variables when local/testing
+C_SDK_VERSION="${C_SDK_VERSION:-v0.1.0}"
+LLVM_VERSION="${LLVM_VERSION:-13}"
+TESTING_TAG="${TESTING_TAG:-v0.0.0-local}"
+TAG=${TAG:-$TESTING_TAG}
+TAG=${TAG/\//-} # replace occurances of "/" with "-" (for test builds with unideal branch name)
+
+# assign variables, will be exported to CI env, or sourced to local shell
+SDK_BIN=qcs-sdk-qir
+ARCH=$(uname -m)
+OS=$(uname -s | awk '{print tolower($0)}')
+DIST=${SDK_BIN}-llvm${LLVM_VERSION}-${OS}-${ARCH}-${TAG}  
+DIST_DIR=${DIST}/dist
+DIST_ABS_PATH=$(pwd)/${DIST_DIR}
+TMP_DEPS_ABS_PATH=$(pwd)/tmp-deps-build
+ARCHIVE=${DIST}.tar.gz
+CHECKSUM=${DIST}.checksum.txt
+
+case $OS in
+    "darwin")
+        LIB_EXT="dylib"
+        ;;
+    "linux")
+        LIB_EXT="so"
+        ;;
+    *)
+        echo "ERROR: unable to build release artifacts for OS: ${OS}"
+        exit 1
+        ;;
+esac
+
+# create paths to build deps
+mkdir -p ${TMP_DEPS_ABS_PATH}
+
+# create paths to collect artifacts
+mkdir -p ${DIST_ABS_PATH}/lib
+
+rm -f .release-env # remove file if it exists
+echo "C_SDK_VERSION=${C_SDK_VERSION}" >> .release-env
+echo "LLVM_VERSION=${LLVM_VERSION}" >> .release-env
+echo "TESTING_TAG=${TESTING_TAG}" >> .release-env
+echo "TAG=${TAG}" >> .release-env
+echo "SDK_BIN=${SDK_BIN}" >> .release-env
+echo "ARCH=${ARCH}" >> .release-env
+echo "OS=${OS}" >> .release-env
+echo "DIST=${DIST}" >> .release-env
+echo "DIST_DIR=${DIST_DIR}" >> .release-env
+echo "DIST_ABS_PATH=${DIST_ABS_PATH}" >> .release-env
+echo "TMP_DEPS_ABS_PATH=${TMP_DEPS_ABS_PATH}" >> .release-env
+echo "ARCHIVE=${ARCHIVE}" >> .release-env
+echo "CHECKSUM=${CHECKSUM}" >> .release-env
+echo "LIB_EXT=${LIB_EXT}" >> .release-env
+
+# print out all env variables
+cat .release-env

--- a/scripts/release/setup.sh
+++ b/scripts/release/setup.sh
@@ -4,20 +4,22 @@ set -xeo pipefail
 # set defaults for dynamic CI variables when local/testing
 C_SDK_VERSION="${C_SDK_VERSION:-v0.1.0}"
 LLVM_VERSION="${LLVM_VERSION:-13}"
+LLVM_FULL_VERSION="${LLVM_FULL_VERSION:-0.1}"
 TESTING_TAG="${TESTING_TAG:-v0.0.0-local}"
 TAG=${TAG:-$TESTING_TAG}
 TAG=${TAG/\//-} # replace occurances of "/" with "-" (for test builds with unideal branch name)
+CI=${CI:-false}
 
 # assign variables, will be exported to CI env, or sourced to local shell
 SDK_BIN=qcs-sdk-qir
 ARCH=$(uname -m)
 OS=$(uname -s | awk '{print tolower($0)}')
-DIST=${SDK_BIN}-llvm${LLVM_VERSION}-${OS}-${ARCH}-${TAG}  
-DIST_DIR=${DIST}/dist
+RELEASE=${SDK_BIN}-llvm${LLVM_VERSION}-${OS}-${ARCH}-${TAG}  
+DIST_DIR=${RELEASE}/dist
 DIST_ABS_PATH=$(pwd)/${DIST_DIR}
 TMP_DEPS_ABS_PATH=$(pwd)/tmp-deps-build
-ARCHIVE=${DIST}.tar.gz
-CHECKSUM=${DIST}.checksum.txt
+ARCHIVE=${RELEASE}.tar.gz
+CHECKSUM=${RELEASE}.checksum.txt
 
 case $OS in
     "darwin")
@@ -46,13 +48,23 @@ echo "TAG=${TAG}" >> .release-env
 echo "SDK_BIN=${SDK_BIN}" >> .release-env
 echo "ARCH=${ARCH}" >> .release-env
 echo "OS=${OS}" >> .release-env
-echo "DIST=${DIST}" >> .release-env
+echo "RELEASE=${RELEASE}" >> .release-env
 echo "DIST_DIR=${DIST_DIR}" >> .release-env
 echo "DIST_ABS_PATH=${DIST_ABS_PATH}" >> .release-env
 echo "TMP_DEPS_ABS_PATH=${TMP_DEPS_ABS_PATH}" >> .release-env
 echo "ARCHIVE=${ARCHIVE}" >> .release-env
 echo "CHECKSUM=${CHECKSUM}" >> .release-env
 echo "LIB_EXT=${LIB_EXT}" >> .release-env
+
+# special treatment for macos-latest github runner clang environment
+if [[ $OS = "darwin" && $CI = "true" ]]; then
+    echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> .release-env
+    echo "CPATH=$LLVM_PATH/lib/clang/$LLVM_FULL_VERSION/include/" >> .release-env
+    echo "LDFLAGS=-L$LLVM_PATH/lib" >> .release-env
+    echo "CPPFLAGS=-I$LLVM_PATH/include" >> .release-env
+    echo "CC=$LLVM_PATH/bin/clang" >> .release-env
+    echo "CXX=$LLVM_PATH/bin/clang++" >> .release-env
+fi
 
 # print out all env variables
 cat .release-env


### PR DESCRIPTION
Closes #25

Enables releases to be easily built locally by running:
- `cargo make release-quick`, which will run the release scripts without any tests. 
- any of `cargo make release-{setup,build,archive}`, which will execute those steps.

Configurability:
- toggle `NO_C_SDK_BUILD=1`, `NO_HELPER_LIB_BUILD=1`, and/or `NO_QIR_SDK_BUILD=1` to disable builds, nice for faster feedback loops locally. e.g. `NO_C_SDK_BUILD=1 cargo make release-build` will skip clone & build of the QCS C SDK (if you've already built it once, unlikely you will need it built again locally)
