### PR TITLE
chore: add script to test e2e bitcode transform + compilation + execute on qpu

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -55,3 +55,7 @@ dependencies = ["release-setup", "release-build", "release-archive"]
 
 [tasks.release-clean]
 command = "./scripts/release/clean.sh"
+
+[tasks.release-test-e2e]
+command = "./scripts/release/test-e2e.sh"
+args = ["${@}"]

--- a/README.md
+++ b/README.md
@@ -48,12 +48,35 @@ NO_C_SDK_BUILD=1 NO_QIR_SDK_BUILD=1 NO_HELPER_LIB_BUILD=1 cargo make release-qui
 # NO_HELPER_LIB_BUILD: skips the build of the helper lib (default: 0)
 ```
 
-Refer to the included `README.md` in your own local release build, which will help you test your
-changes if you are looking to transform and compile QIR programs. 
-
 To reset your environment and clean up release build artifacts, run:
 ```sh
 cargo make release-clean
+```
+
+## Testing
+
+Refer to the included `README.md` in your own local release build, which will help you test your
+changes if you are looking to transform and compile QIR programs. 
+
+For a full end-to-end integration test against both `qvm` and QPUs, you can use:
+
+```sh
+cargo make release-test-e2e <TARGET> <PROGRAM>
+# TARGET = one of: qvm, Aspen-11, Aspen-M-1
+# PROGRAM = path to an LLVM bitcode (.bc) file to transform and compile into executable format
+```
+
+```sh
+cargo make release-test-e2e
+# defaults to:
+# cargo make release-test-e2e qvm tests/fixtures/programs/reduction.bc
+# use any of {qvm,Aspen-11,Aspen-M-1}, assuming you can access the QPUs.
+
+# using the default test program
+cargo make release-test-e2e Aspen-11
+
+# using a different test program (note: target must be provided, args are positional)
+cargo make release-test-e2e Aspen-11 ./input.bc 
 ```
 
 ## Examples

--- a/scripts/release/test-e2e.sh
+++ b/scripts/release/test-e2e.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [ ! -f .release-env ]; then
+    echo "no .release-env setup file, please run:"
+    echo "$ cargo make release-setup"
+fi
+
+source .release-env
+
+if [ ! -d "$DIST_DIR" ]; then 
+    echo "no release available to test, please run:"
+    echo "$ cargo make release-quick"
+fi
+
+case $1 in
+    "")
+esac
+
+TEST_TARGET=${1:-"qvm"}
+TEST_INPUT=${2:-"tests/fixtures/programs/reduction.bc"}
+
+case $TEST_TARGET in 
+    "Aspen-11"|"Aspen-M-1"|"qvm")
+    ;;
+
+    *)
+        echo "Invalid target '${TEST_TARGET}'. Use one of 'Aspen-11', 'Aspen-M-1', or 'qvm' (default)."
+        exit 1
+    ;;
+esac
+
+echo "Targeting: '${TEST_TARGET}'..."
+
+case $TEST_TARGET in 
+    "Aspen-11"|"Aspen-M-1")
+        echo "Ensure your networking configuration allows connectivity to QPUs."
+    ;;
+esac
+
+echo "Transforming '${TEST_INPUT}', compiling into executable."
+
+case $OS in
+    "darwin"|"linux")
+        if [ $OS = "darwin" ]; then
+            export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:./lib
+        else
+            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./lib
+        fi
+
+        pushd $DIST_DIR
+        ./qcs-sdk-qir transform --add-main-entrypoint --target $TEST_TARGET ../../$TEST_INPUT output.bc
+        clang -Llib -lqcs -Llib -lhelper output.bc -o program
+        ./program
+        popd
+    ;;
+
+    *)
+        echo "Unsupported system platform: '${OS}'"
+    ;;
+esac

--- a/scripts/release/test-e2e.sh
+++ b/scripts/release/test-e2e.sh
@@ -47,20 +47,30 @@ esac
 echo "Transforming: '${TEST_INPUT}' -> '${DIST_DIR}/output.bc'"
 echo "Compiling: '${DIST_DIR}/program'"
 
+
 # transform and compile the program, then run against specified target
 case $OS in
     "darwin"|"linux")
         if [ $OS = "darwin" ]; then
+            RESTORE_LIBRARY_PATH=$DYLD_LIBRARY_PATH
             export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:./lib
         else
+            RESTORE_LIBRARY_PATH=$LD_LIBRARY_PATH
             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./lib
         fi
-
+                
         pushd $DIST_DIR
         ./qcs-sdk-qir transform --add-main-entrypoint --target $TEST_TARGET $TEST_INPUT output.bc
         clang -Llib -lqcs -Llib -lhelper output.bc -o program
         ./program
         popd
+        
+        
+        if [ $OS = "darwin" ]; then
+            export DYLD_LIBRARY_PATH=$RESTORE_LIBRARY_PATH
+        else
+            export LD_LIBRARY_PATH=$RESTORE_LIBRARY_PATH
+        fi
     ;;
 
     *)

--- a/scripts/release/test-e2e.sh
+++ b/scripts/release/test-e2e.sh
@@ -44,7 +44,8 @@ case $TEST_TARGET in
     ;;
 esac
 
-echo "Transforming '${TEST_INPUT}', compiling into executable."
+echo "Transforming: '${TEST_INPUT}' -> '${DIST_DIR}/output.bc'"
+echo "Compiling: '${DIST_DIR}/program'"
 
 # transform and compile the program, then run against specified target
 case $OS in

--- a/scripts/release/test-e2e.sh
+++ b/scripts/release/test-e2e.sh
@@ -13,10 +13,6 @@ if [ ! -d "$DIST_DIR" ]; then
     echo "$ cargo make release-quick"
 fi
 
-case $1 in
-    "")
-esac
-
 TEST_TARGET=${1:-"qvm"}
 TEST_INPUT=${2:-"tests/fixtures/programs/reduction.bc"}
 


### PR DESCRIPTION
This PR adds a simple script / cargo-make command to run a configurable e2e test of IR transformation + compilation to executable format + program execution.

_(Added to the README)_

> For a full end-to-end integration test against both `qvm` and QPUs, you can use:
> 
> ```sh
> cargo make release-test-e2e <TARGET> <PROGRAM>
> # TARGET = one of: qvm, Aspen-11, Aspen-M-1
> # PROGRAM = path to an LLVM bitcode (.bc) file to transform and compile into executable format
> ```
> 
> ```sh
> cargo make release-test-e2e
> # defaults to:
> # cargo make release-test-e2e qvm tests/fixtures/programs/reduction.bc
> # use any of {qvm,Aspen-11,Aspen-M-1}, assuming you can access the QPUs.
> 
> # using the default test program
> cargo make release-test-e2e Aspen-11
> 
> # using a different test program (note: target must be provided, args are positional)
> cargo make release-test-e2e Aspen-11 ./input.bc 
> ```