### PR TITLE
New: Allow skipping the `qcs` dependency via features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "3.1.6", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1"
-qcs = "0.2.2"
+qcs = { version = "0.2.2", optional = true }
 
 [dependencies.inkwell]
 version = "0.1.0"
@@ -36,7 +36,8 @@ trycmd = "0.13.3"
 
 [features]
 cli = ["clap"]
-default = ["serde_support", "cli"]
+output = ["qcs"]   # Enables the `output` module
+default = ["serde_support", "cli", "output"]
 llvm12-0 = ["inkwell/llvm12-0"]
 llvm13-0 = ["inkwell/llvm13-0"]
 serde_support = ["serde", "serde_json"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use context::target::ExecutionTarget;
 /// This module contains different functions intended for use as LLVM passes.
 pub(crate) mod context;
 pub(crate) mod interop;
+#[cfg(feature = "output")]
 pub mod output;
 pub(crate) mod transform;
 


### PR DESCRIPTION
In the same spirit as #39 — one less dependency to balance when the output formatting stuff is not being used.