### PR TITLE
feat: relax `transpile_function` to permit standards-compliant `i64` return type

### DIFF
--- a/.github/workflows/ci-unix.yml
+++ b/.github/workflows/ci-unix.yml
@@ -31,6 +31,13 @@ jobs:
       with:
         version: "${{ matrix.llvm_version }}.0"
 
+    - name: Show llvm-config output for debugging purposes
+      run: |
+        for flag in build-mode cflags libdir libnames system-libs version; do
+          echo "\$ llvm-config --$flag"
+          llvm-config --$flag
+        done
+
     - name: Install cargo-make
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/ci-unix.yml
+++ b/.github/workflows/ci-unix.yml
@@ -31,6 +31,10 @@ jobs:
       with:
         version: "${{ matrix.llvm_version }}.0"
 
+    - name: Install missing LLVM deps
+      if: contains(matrix.os, 'ubuntu')
+      run: sudo apt-get install -y libtinfo5
+
     - name: Show llvm-config output for debugging purposes
       run: |
         for flag in build-mode cflags libdir libnames system-libs version; do

--- a/.github/workflows/ci-unix.yml
+++ b/.github/workflows/ci-unix.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, debian-bookworm]
+        os: [macos-latest, ubuntu-22.04]
         rust:
           - stable
         llvm_version: [12, 13]

--- a/.github/workflows/ci-unix.yml
+++ b/.github/workflows/ci-unix.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, debian-bookworm]
         rust:
           - stable
         llvm_version: [12, 13]
@@ -29,12 +29,6 @@ jobs:
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "${{ matrix.llvm_version }}.0"
-
-    - name: Install missing LLVM deps
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-        sudo apt-get update && sudo apt-get install -y libtinfo5
 
     - name: Install cargo-make
       uses: actions-rs/cargo@v1

--- a/.github/workflows/ci-unix.yml
+++ b/.github/workflows/ci-unix.yml
@@ -12,6 +12,7 @@ jobs:
         rust:
           - stable
         llvm_version: [12, 13]
+      fail-fast: false
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/.github/workflows/ci-unix.yml
+++ b/.github/workflows/ci-unix.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-22.04]
+        # macOS: Intel processor; oldest version GitHub provides as of 2025-07-28
+        # Ubuntu: LTS version based on Debian Bookworm
+        os: [macos-13, ubuntu-22.04]
         rust:
           - stable
         llvm_version: [12, 13]

--- a/.github/workflows/release-unix.yml
+++ b/.github/workflows/release-unix.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, debian-bookworm]
+        # macOS: Intel processor; oldest version GitHub provides as of 2025-07-28
+        # Ubuntu: LTS version based on Debian Bookworm
+        os: [macos-13, ubuntu-22.04]
         rust:
           - stable
         llvm_version: [12, 13]
@@ -36,6 +38,10 @@ jobs:
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "${{ matrix.llvm_version }}.0"
+
+    - name: Install missing LLVM deps
+      if: contains(matrix.os, 'ubuntu')
+      run: sudo apt-get install -y libtinfo5
     
     - name: Check LLVM installation
       run: llvm-config --version

--- a/.github/workflows/release-unix.yml
+++ b/.github/workflows/release-unix.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, debian-bookworm]
         rust:
           - stable
         llvm_version: [12, 13]
@@ -36,12 +36,6 @@ jobs:
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "${{ matrix.llvm_version }}.0"
-
-    - name: Install missing LLVM deps
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-        sudo apt-get update && sudo apt-get install -y libtinfo5 cmake
     
     - name: Check LLVM installation
       run: llvm-config --version

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -25,7 +25,7 @@ args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
 command = "cargo"
-args = ["clippy", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}"]
+args = ["clippy", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}", "${@}"]
 
 [tasks.pre-ci-flow]
 dependencies = ["format-check", "clippy"]

--- a/src/interop/call.rs
+++ b/src/interop/call.rs
@@ -22,7 +22,7 @@ use inkwell::{
 use crate::context::QCSCompilerContext;
 
 #[allow(dead_code)]
-pub(crate) fn printf<'ctx>(context: &mut QCSCompilerContext<'ctx>, string: PointerValue) {
+pub(crate) fn printf(context: &mut QCSCompilerContext<'_>, string: PointerValue) {
     let string_type = context.types.string();
     let printf_type = context
         .base_context

--- a/src/interop/entrypoint.rs
+++ b/src/interop/entrypoint.rs
@@ -25,7 +25,7 @@ use crate::context::QCSCompilerContext;
 pub(crate) fn get_entry_function<'ctx>(module: &Module<'ctx>) -> Option<FunctionValue<'ctx>> {
     let ns = "QuantumApplication";
     let method = "Run";
-    let entrypoint_name = format!("{}__{}__body", ns, method);
+    let entrypoint_name = format!("{ns}__{method}__body");
     get_entrypoint_function(module).or_else(|| module.get_function(&entrypoint_name))
 }
 

--- a/src/output/debug.rs
+++ b/src/output/debug.rs
@@ -44,17 +44,17 @@ impl OutputFormat for DebugOutputFormat {
                         let shot_id = shot_idx + 1;
                         match recorded_output {
                             RecordedOutput::ShotStart => {
-                                output.push(format!("[shot:{} start]", shot_id));
+                                output.push(format!("[shot:{shot_id} start]"));
                             }
                             RecordedOutput::ShotEnd => {
-                                output.push(format!("[shot:{} end]", shot_id));
+                                output.push(format!("[shot:{shot_id} end]"));
                                 break;
                             }
                             RecordedOutput::ResultReadoutOffset(index) => {
                                 #[allow(clippy::cast_possible_truncation)]
                                 let index = *index as usize;
                                 if let Some(result) = shot.get(index) {
-                                    output.push(format!("[shot:{} result {}]", shot_id, result));
+                                    output.push(format!("[shot:{shot_id} result {result}]"));
                                 } else {
                                     return Err(Error::NoShotDataAtIndex(shot_id, index));
                                 }
@@ -63,21 +63,20 @@ impl OutputFormat for DebugOutputFormat {
                             | RecordedOutput::IntegerReadoutOffset(..)
                             | RecordedOutput::DoubleReadoutOffset(..) => {
                                 return Err(Error::UnimplementedRecordType(format!(
-                                    "{:?}",
-                                    recorded_output
+                                    "{recorded_output:?}"
                                 )))
                             }
                             RecordedOutput::TupleStart => {
-                                output.push(format!("[shot:{} tuple_start]", shot_id));
+                                output.push(format!("[shot:{shot_id} tuple_start]"));
                             }
                             RecordedOutput::TupleEnd => {
-                                output.push(format!("[shot:{} tuple_end]", shot_id));
+                                output.push(format!("[shot:{shot_id} tuple_end]"));
                             }
                             RecordedOutput::ArrayStart => {
-                                output.push(format!("[shot:{} array_start]", shot_id));
+                                output.push(format!("[shot:{shot_id} array_start]"));
                             }
                             RecordedOutput::ArrayEnd => {
-                                output.push(format!("[shot:{} array_end]", shot_id));
+                                output.push(format!("[shot:{shot_id} array_end]"));
                             }
                         }
                     }
@@ -85,7 +84,7 @@ impl OutputFormat for DebugOutputFormat {
                 Ok(Self(output))
             }
             RegisterData::Complex32(..) | RegisterData::F64(..) | RegisterData::I16(..) => {
-                Err(Error::UnimplementedResultType(format!("{:?}", result)))
+                Err(Error::UnimplementedResultType(format!("{result:?}")))
             }
         }
     }
@@ -112,7 +111,7 @@ fn test_execution_result_debug_output() {
     let output = DebugOutputFormat::try_new(&execution_result, &mapping).unwrap();
     assert_eq!(output.0.len(), 15);
 
-    const EXPECTED_OUTPUT: &str = r#"
+    const EXPECTED_OUTPUT: &str = r"
 [shot:1 start]
 [shot:1 result 1]
 [shot:1 result 2]
@@ -128,12 +127,12 @@ fn test_execution_result_debug_output() {
 [shot:3 result 22]
 [shot:3 result 33]
 [shot:3 end]
-"#;
+";
 
     assert_eq!(
         super::try_format::<DebugOutputFormat>(&execution_result, &mapping).unwrap(),
         EXPECTED_OUTPUT.trim()
-    )
+    );
 }
 
 #[test]
@@ -151,7 +150,7 @@ fn test_out_of_range_debug_output() {
     let try_output = DebugOutputFormat::try_new(&execution_result, &mapping);
     if let Some(Error::NoShotDataAtIndex(shot_id, index)) = try_output.err() {
         assert_eq!(shot_id, 2);
-        assert_eq!(index, 2)
+        assert_eq!(index, 2);
     } else {
         assert!(false);
     }

--- a/src/transform/shot_count_block/qir.rs
+++ b/src/transform/shot_count_block/qir.rs
@@ -133,7 +133,7 @@ pub(crate) fn transpile_module(context: &mut QCSCompilerContext) -> Result<()> {
             context.builder.position_before(&instruction);
         }
         None => context.builder.position_at_end(entry_basic_block),
-    };
+    }
 
     context.builder.build_call(populate_function, &[], "");
 

--- a/src/transform/unitary/qir.rs
+++ b/src/transform/unitary/qir.rs
@@ -128,7 +128,7 @@ pub(crate) fn transpile_module(context: &mut QCSCompilerContext) -> Result<()> {
             context.builder.position_before(&instruction);
         }
         None => context.builder.position_at_end(entry_basic_block),
-    };
+    }
 
     context.builder.build_call(populate_function, &[], "");
 

--- a/src/transform/unitary/quil.rs
+++ b/src/transform/unitary/quil.rs
@@ -80,7 +80,7 @@ pub(crate) fn transpile_function<'ctx>(
             .is_none_or(|ret_ty| ret_ty == context.base_context.i64_type().into()))
     {
         return Err(eyre::eyre!(
-            "expected function to return void; found {}",
+            "expected function to return i64 or (as a legacy extension) void; found {}",
             func_ty.print_to_string()
         ));
     }

--- a/src/transform/unitary/quil.rs
+++ b/src/transform/unitary/quil.rs
@@ -80,7 +80,9 @@ pub(crate) fn transpile_function<'ctx>(
             .is_none_or(|ret_ty| ret_ty == context.base_context.i64_type().into()))
     {
         return Err(eyre::eyre!(
-            "expected function to return i64 or (as a legacy extension) void; found {}",
+            "expected function to take no arguments \
+             and return i64 or (as a legacy extension) void; \
+             instead, function had type {}",
             func_ty.print_to_string()
         ));
     }


### PR DESCRIPTION
This should address @swernli's [comment](https://github.com/rigetti/qcs-sdk-qir/issues/50#issuecomment-2037851427) on #50.