### PR TITLE
fix: don't require an optional dependency for re-exported imports

### DIFF
--- a/.github/workflows/ci-unix.yml
+++ b/.github/workflows/ci-unix.yml
@@ -16,7 +16,7 @@ jobs:
         os: [macos-13, ubuntu-22.04]
         rust:
           - stable
-        llvm_version: [12, 13]
+        llvm_version: [13, 14]
       fail-fast: false
     steps:
     - name: Checkout sources

--- a/.github/workflows/release-unix.yml
+++ b/.github/workflows/release-unix.yml
@@ -15,7 +15,7 @@ jobs:
         os: [macos-13, ubuntu-22.04]
         rust:
           - stable
-        llvm_version: [12, 13]
+        llvm_version: [13, 14]
     env:
       C_SDK_VERSION: v0.1.1
       LLVM_VERSION: ${{ matrix.llvm_version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,8 +1486,8 @@ dependencies = [
  "either",
  "inkwell_internals",
  "libc",
- "llvm-sys 120.3.2",
  "llvm-sys 130.1.2",
+ "llvm-sys 140.1.3",
  "once_cell",
  "thiserror 1.0.69",
 ]
@@ -1783,9 +1783,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "llvm-sys"
-version = "120.3.2"
+version = "130.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624f2692f436769c7eb85a13eeca3f6fb9705a4b2bd0473ac9577c90f19e21ef"
+checksum = "c20142c91fc4bde4036edbaf0d112f79667831d612efbaabe862ab9748fdd67c"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1796,15 +1796,15 @@ dependencies = [
 
 [[package]]
 name = "llvm-sys"
-version = "130.1.2"
+version = "140.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20142c91fc4bde4036edbaf0d112f79667831d612efbaabe862ab9748fdd67c"
+checksum = "e3dc78e9857c0231ec11e3bdccf63870493fdc7d0570b0ea7d50bf5df0cb1a0c"
 dependencies = [
  "cc",
  "lazy_static",
  "libc",
  "regex",
- "semver 0.11.0",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -2592,6 +2592,7 @@ dependencies = [
  "log",
  "num-complex",
  "qcs",
+ "quil-rs",
  "regex",
  "serde",
  "serde_json",
@@ -2962,7 +2963,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.7",
  "subtle",
  "zeroize",
 ]
@@ -3024,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,11 @@ serde_support = ["serde", "serde_json"]
 name = "qcs-sdk-qir"
 path = "src/main.rs"
 required-features = ["cli"]
+
+[[test]]
+name = "public_lib_api"
+required-features = ["output", "serde_support"]
+
+[[test]]
+name = "snapshots"
+required-features = ["output", "serde_support"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,10 @@ inkwell = { version = "0.6.0", features = ["target-x86"] }
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-complex = "0.4.0"
-# qcs re-exports quil-rs. We use this re-exported version for consistency.
-# quil-rs types are part of the public API, major versions are breaking changes.
 qcs = { version = "0.25.11", optional = true }
+# qcs re-exports quil-rs. We use the same version as it for consistency.
+# quil-rs types are part of the public API, major versions are breaking changes.
+quil-rs = "0.29"
 regex = "1.5.4"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
@@ -34,8 +35,8 @@ trycmd = "0.15"
 cli = ["clap"]
 output = ["qcs"]   # Enables the `output` module
 default = ["serde_support", "cli", "output"]
-llvm12-0 = ["inkwell/llvm12-0"]
 llvm13-0 = ["inkwell/llvm13-0"]
+llvm14-0 = ["inkwell/llvm14-0"]
 serde_support = ["serde", "serde_json"]
 
 [[bin]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,6 +14,12 @@ NO_HELPER_LIB_BUILD = { value = "0", condition = { env_not_set = [
     "NO_HELPER_LIB_BUILD",
 ] } }
 
+[tasks.hack]
+private = true
+command = "cargo"
+args = ["hack", "--feature-powerset", "--mutually-exclusive-features", "llvm13-0,llvm14-0",
+"--at-least-one-of", "llvm13-0,llvm14-0", "${HACK_COMMAND}", "--profile", "${PROFILE}", "--all-targets"]
+
 [tasks.assemble-llvm]
 command = "find"
 description = "Assemble all LLVM .ll files in this package into bitcode"
@@ -24,8 +30,9 @@ command = "cargo"
 args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
-command = "cargo"
-args = ["clippy", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}", "${@}"]
+clear = true
+run_task = "hack"
+env = { HACK_COMMAND = "clippy" }
 
 [tasks.pre-ci-flow]
 dependencies = ["format-check", "clippy"]
@@ -34,7 +41,9 @@ dependencies = ["format-check", "clippy"]
 args = ["build", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}"]
 
 [tasks.test]
-args = ["test", "--features", "${LLVM_FEATURE}", "--profile", "${PROFILE}"]
+clear = true
+run_task = "hack"
+env = { HACK_COMMAND = "test" }
 
 [tasks.release-setup]
 command = "./scripts/release/setup.sh"

--- a/src/context/context.rs
+++ b/src/context/context.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use eyre::Result;
-use qcs::quil_rs::Program;
+use quil_rs::Program;
 
 use crate::interop::load::load_module_from_bitcode;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use eyre::{Report, Result};
 use qcs_sdk_qir::{ExecutionTarget, PatchOptions};
 
 #[cfg(not(feature = "serde_support"))]
-use qcs::quil_rs::quil::Quil;
+use quil_rs::quil::Quil;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -145,7 +145,7 @@ fn main() -> Result<()> {
                     #[cfg(not(feature = "serde_support"))]
                     {
                         println!("shot count: {}\n", output.shot_count);
-                        println!("quil:\n{}", output.program.to_quil());
+                        println!("quil:\n{}", output.program.to_quil()?);
                         println!("recorded output:\n{:#?}", output.recorded_output);
                     }
                 }
@@ -157,7 +157,7 @@ fn main() -> Result<()> {
 
                     #[cfg(not(feature = "serde_support"))]
                     {
-                        println!("quil:\n{}", output.program.to_quil());
+                        println!("quil:\n{}", output.program.to_quil()?);
                         println!("recorded output:\n{:#?}", output.recorded_output);
                     }
                 }

--- a/src/transform/shot_count_block/pattern.rs
+++ b/src/transform/shot_count_block/pattern.rs
@@ -30,9 +30,9 @@ use inkwell::{
     },
 };
 use log::{debug, info};
-use qcs::quil_rs::instruction::{Gate, Instruction, Measurement};
-use qcs::quil_rs::Program;
-use qcs::quil_rs::{
+use quil_rs::instruction::{Gate, Instruction, Measurement};
+use quil_rs::Program;
+use quil_rs::{
     expression::Expression,
     instruction::{GateModifier, MemoryReference, Qubit},
 };

--- a/src/transform/shot_count_block/qir.rs
+++ b/src/transform/shot_count_block/qir.rs
@@ -18,11 +18,11 @@ use inkwell::{
     values::{AnyValue, FunctionValue, InstructionValue},
 };
 use log::{debug, info};
-use qcs::quil_rs::instruction::{
+use quil_rs::instruction::{
     Declaration, Instruction, Pragma, PragmaArgument, Reset, ScalarType, Vector,
 };
-use qcs::quil_rs::quil::Quil;
-use qcs::quil_rs::Program;
+use quil_rs::quil::Quil;
+use quil_rs::Program;
 
 use crate::interop::{
     call,

--- a/src/transform/shot_count_block/quil.rs
+++ b/src/transform/shot_count_block/quil.rs
@@ -17,11 +17,11 @@
 // executing those quil instructions.
 use eyre::{eyre, Result};
 use inkwell::{basic_block::BasicBlock, values::FunctionValue};
-use qcs::quil_rs::instruction::{
+use quil_rs::instruction::{
     Declaration, Instruction, Pragma, PragmaArgument, Reset, ScalarType, Vector,
 };
 
-use qcs::quil_rs::Program;
+use quil_rs::Program;
 #[cfg(feature = "serde_support")]
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
@@ -47,7 +47,7 @@ impl Serialize for ProgramOutput {
     where
         S: Serializer,
     {
-        use qcs::quil_rs::quil::Quil;
+        use quil_rs::quil::Quil;
         use serde::ser::Error;
 
         let mut output = serializer.serialize_struct("ProgramOutput", 3)?;
@@ -194,7 +194,7 @@ mod test {
         use super::*;
         use crate::context::context::{ContextOptions, QCSCompilerContext};
         use crate::context::target::ExecutionTarget;
-        use qcs::quil_rs::quil::Quil;
+        use quil_rs::quil::Quil;
 
         macro_rules! make_snapshot_test {
             ($name:ident) => {

--- a/src/transform/unitary/pattern.rs
+++ b/src/transform/unitary/pattern.rs
@@ -20,9 +20,9 @@ use inkwell::{
     values::{FloatValue, InstructionOpcode, InstructionValue},
 };
 use log::{debug, info};
-use qcs::quil_rs::instruction::{Gate, Instruction, Measurement};
-use qcs::quil_rs::Program;
-use qcs::quil_rs::{
+use quil_rs::instruction::{Gate, Instruction, Measurement};
+use quil_rs::Program;
+use quil_rs::{
     expression::Expression,
     instruction::{GateModifier, MemoryReference, Qubit},
 };

--- a/src/transform/unitary/qir.rs
+++ b/src/transform/unitary/qir.rs
@@ -18,11 +18,11 @@ use inkwell::{
     values::{FunctionValue, InstructionOpcode},
 };
 use log::{debug, info};
-use qcs::quil_rs::instruction::{
+use quil_rs::instruction::{
     Declaration, Instruction, Pragma, PragmaArgument, Reset, ScalarType, Vector,
 };
-use qcs::quil_rs::quil::Quil;
-use qcs::quil_rs::Program;
+use quil_rs::quil::Quil;
+use quil_rs::Program;
 
 use crate::interop::{
     call, entrypoint::get_entry_function, instruction::remove_instructions_in_safe_order,

--- a/src/transform/unitary/quil.rs
+++ b/src/transform/unitary/quil.rs
@@ -22,10 +22,10 @@ use inkwell::types::AnyType;
 
 use inkwell::{basic_block::BasicBlock, values::FunctionValue};
 
-use qcs::quil_rs::instruction::{
+use quil_rs::instruction::{
     Declaration, Instruction, Pragma, PragmaArgument, Reset, ScalarType, Vector,
 };
-use qcs::quil_rs::Program;
+use quil_rs::Program;
 #[cfg(feature = "serde_support")]
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
@@ -52,7 +52,7 @@ impl Serialize for ProgramOutput {
     where
         S: Serializer,
     {
-        use qcs::quil_rs::quil::Quil;
+        use quil_rs::quil::Quil;
         use serde::ser::Error;
         let mut output = serializer.serialize_struct("ProgramOutput", 3)?;
         let quil = self.program.to_quil().map_err(S::Error::custom)?;
@@ -219,7 +219,7 @@ mod test {
         use super::*;
         use crate::context::context::{ContextOptions, QCSCompilerContext};
         use crate::context::target::ExecutionTarget;
-        use qcs::quil_rs::quil::Quil;
+        use quil_rs::quil::Quil;
 
         macro_rules! make_snapshot_test {
             ($name:ident) => {

--- a/tests/public_lib_api.rs
+++ b/tests/public_lib_api.rs
@@ -1,11 +1,11 @@
 use std::fs::read;
 
-use quil_rs::quil::Quil;
 use qcs::RegisterData;
 use qcs_sdk_qir::{
     output::{self, DebugOutputFormat},
     transpile_qir_to_quil,
 };
+use quil_rs::quil::Quil;
 
 #[test]
 fn transpile_qir_to_quil_bell_state() {

--- a/tests/public_lib_api.rs
+++ b/tests/public_lib_api.rs
@@ -1,6 +1,6 @@
 use std::fs::read;
 
-use qcs::quil_rs::quil::Quil;
+use quil_rs::quil::Quil;
 use qcs::RegisterData;
 use qcs_sdk_qir::{
     output::{self, DebugOutputFormat},


### PR DESCRIPTION
In #52 I replaced imports of `quil_rs` with `qcs::quil_rs`, with the rationale of avoiding a situation where `quil-rs` had multiple versions. I did not catch that `qcs` is an optional dependency that is enabled by a default feature.

This PR restores `quil-rs` as a dependency while ensuring the version is consistent with the one used by `qcs`. It also updates `Makefile.toml` to use `cargo hack` for linting and tests, to help prevent this sort of situation in the future.